### PR TITLE
Remove non default entities from default workflows

### DIFF
--- a/Microsoft Dynamics.json
+++ b/Microsoft Dynamics.json
@@ -84,24 +84,6 @@
             "entity": "lead"
           },
           {
-            "entity": "appointment",
-            "dependsOn": [
-              {
-                "field": "RegardingObjectId",
-                "entity": "lead"
-              }
-            ]
-          },
-          {
-            "entity": "task",
-            "dependsOn": [
-              {
-                "field": "RegardingObjectId",
-                "entity": "lead"
-              }
-            ]
-          },
-          {
             "entity": "attachments",
             "config": {
               "drawing": {
@@ -151,24 +133,6 @@
               {
                 "field": "ParentCustomerId",
                 "entity": "account"
-              }
-            ]
-          },
-          {
-            "entity": "appointment",
-            "dependsOn": [
-              {
-                "field": "RegardingObjectId",
-                "entity": "contact"
-              }
-            ]
-          },
-          {
-            "entity": "task",
-            "dependsOn": [
-              {
-                "field": "RegardingObjectId",
-                "entity": "contact"
               }
             ]
           },
@@ -281,24 +245,6 @@
               "entity": "lead"
             },
             {
-              "entity": "appointment",
-              "dependsOn": [
-                {
-                  "field": "RegardingObjectId",
-                  "entity": "lead"
-                }
-              ]
-            },
-            {
-              "entity": "task",
-              "dependsOn": [
-                {
-                  "field": "RegardingObjectId",
-                  "entity": "lead"
-                }
-              ]
-            },
-            {
               "entity": "attachments",
               "config": {
                 "drawing": {
@@ -354,24 +300,6 @@
                 {
                   "field": "ParentCustomerId",
                   "entity": "account"
-                }
-              ]
-            },
-            {
-              "entity": "appointment",
-              "dependsOn": [
-                {
-                  "field": "RegardingObjectId",
-                  "entity": "contact"
-                }
-              ]
-            },
-            {
-              "entity": "task",
-              "dependsOn": [
-                {
-                  "field": "RegardingObjectId",
-                  "entity": "contact"
                 }
               ]
             },

--- a/Salesforce.json
+++ b/Salesforce.json
@@ -84,25 +84,6 @@
             "entity": "lead"
           },
           {
-            "entity": "campaignMember",
-            "dependsOn": [
-              {
-                "field": "LeadId",
-                "entity": "lead"
-              }
-            ],
-            "onError": "skip"
-          },
-          {
-            "entity": "task",
-            "dependsOn": [
-              {
-                "field": "LeadId",
-                "entity": "lead"
-              }
-            ]
-          },
-          {
             "entity": "attachments",
             "config": {
               "bcImage": {
@@ -158,25 +139,6 @@
               {
                 "field": "AccountId",
                 "entity": "account"
-              }
-            ]
-          },
-          {
-            "entity": "campaignMember",
-            "dependsOn": [
-              {
-                "field": "ContactId",
-                "entity": "contact"
-              }
-            ],
-            "onError": "skip"
-          },
-          {
-            "entity": "task",
-            "dependsOn": [
-              {
-                "field": "ContactId",
-                "entity": "contact"
               }
             ]
           },
@@ -300,25 +262,6 @@
               "entity": "lead"
             },
             {
-              "entity": "campaignMember",
-              "dependsOn": [
-                {
-                  "field": "LeadId",
-                  "entity": "lead"
-                }
-              ],
-              "onError": "skip"
-            },
-            {
-              "entity": "task",
-              "dependsOn": [
-                {
-                  "field": "LeadId",
-                  "entity": "lead"
-                }
-              ]
-            },
-            {
               "entity": "attachments",
               "config": {
                 "bcImage": {
@@ -380,25 +323,6 @@
                 {
                   "field": "AccountId",
                   "entity": "account"
-                }
-              ]
-            },
-            {
-              "entity": "campaignMember",
-              "dependsOn": [
-                {
-                  "field": "ContactId",
-                  "entity": "contact"
-                }
-              ],
-              "onError": "skip"
-            },
-            {
-              "entity": "task",
-              "dependsOn": [
-                {
-                  "field": "ContactId",
-                  "entity": "contact"
                 }
               ]
             },


### PR DESCRIPTION
We decided in our Jour Fixe (Planning Sprint 99) to remove the non default entities from our default custommapping templates.

Salesforce: 
- CampaignMember
- Task

Dynamics
- Appointment
- Task