### PR TITLE
feat: Add default mapping to open deals after export to Pipedrive

### DIFF
--- a/Pipedrive.json
+++ b/Pipedrive.json
@@ -237,6 +237,11 @@
             "detailsTemplate": "{{ type }}"
           }
         ]
+      },
+      "config": {
+        "default": {
+          "open": "deal"
+        }
       }
     },
     "visitreport": {

--- a/Pipedrive.json
+++ b/Pipedrive.json
@@ -464,6 +464,11 @@
             }
           ]
         }
+      },
+      "config": {
+        "default": {
+          "open": "deal"
+        }
       }
     },
     "code": {


### PR DESCRIPTION
Adds a default mapping for Pipedrive exports to link to the exported deal.