### PR TITLE
fix(): null-proof duplicate templates

### DIFF
--- a/components/Microsoft Dynamics Grabber.json
+++ b/components/Microsoft Dynamics Grabber.json
@@ -189,7 +189,7 @@
               "FullName"
             ]
           },
-          "mainTemplate": "{{ FirstName }} {{ LastName }}",
+          "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
           "detailsTemplate": "{{ CompanyName }}"
         },
         {
@@ -235,7 +235,6 @@
         },
         {
           "type": "task",
-          "duplicateCheckName": "task",
           "label": {
             "en": "Task",
             "de": "Task"
@@ -273,14 +272,7 @@
               },
               "properties": {}
             }
-          },
-          "search": {
-            "ids": [
-              "Subject"
-            ]
-          },
-          "mainTemplate": "{{ Subject }}",
-          "detailsTemplate": ""
+          }
         }
       ],
       "contact_account": [
@@ -484,7 +476,7 @@
               "FullName"
             ]
           },
-          "mainTemplate": "{{ FirstName }} {{ LastName }}",
+          "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
           "detailsTemplate": "{{ Company }}"
         },
         {
@@ -597,7 +589,7 @@
             ]
           },
           "mainTemplate": "{{ Name }}",
-          "detailsTemplate": "{{ Address1_PostalCode }} - {{ Address1_City }}"
+          "detailsTemplate": "{{ Address1_PostalCode || '' }} - {{ Address1_City || '' }}"
         },
         {
           "type": "appointment",

--- a/components/Microsoft Dynamics VisitReport.json
+++ b/components/Microsoft Dynamics VisitReport.json
@@ -190,7 +190,7 @@
                 "FullName"
               ]
             },
-            "mainTemplate": "{{ FirstName }} {{ LastName }}",
+            "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
             "detailsTemplate": "{{ CompanyName }}"
           },
           {
@@ -477,7 +477,7 @@
                 "FullName"
               ]
             },
-            "mainTemplate": "{{ FirstName }} {{ LastName }}",
+            "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
             "detailsTemplate": "{{ Company }}"
           },
           {
@@ -590,7 +590,7 @@
               ]
             },
             "mainTemplate": "{{ Name }}",
-            "detailsTemplate": "{{ Address1_PostalCode }} - {{ Address1_City }}"
+            "detailsTemplate": "{{ Address1_PostalCode || '' }} - {{ Address1_City || '' }}"
           },
           {
             "type": "appointment",

--- a/components/Pipedrive Grabber.json
+++ b/components/Pipedrive Grabber.json
@@ -147,7 +147,7 @@
           ]
         },
         "mainTemplate": "{{ name }}",
-        "detailsTemplate": "{{ address_postal_code ? address_postal_code + ' - ' : '' }} {{ address_locality }}"
+        "detailsTemplate": "{{ address_postal_code ? address_postal_code + ' - ' : '' }} {{ address_locality || '' }}"
       },
       {
         "type": "deal",
@@ -225,7 +225,7 @@
           ]
         },
         "mainTemplate": "{{ title }}",
-        "detailsTemplate": "{{ person_name ? person_name + ' - ' : '' }} {{ org_name }}"
+        "detailsTemplate": "{{ person_name ? person_name + ' - ' : '' }} {{ org_name || '' }}"
       },
       {
         "type": "activity",

--- a/components/Pipedrive VisitReport.json
+++ b/components/Pipedrive VisitReport.json
@@ -148,7 +148,7 @@
             ]
           },
           "mainTemplate": "{{ name }}",
-          "detailsTemplate": "{{ address_postal_code ? address_postal_code + ' - ' : '' }} {{ address_locality }}"
+          "detailsTemplate": "{{ address_postal_code ? address_postal_code + ' - ' : '' }} {{ address_locality || '' }}"
         },
         {
           "type": "deal",
@@ -226,7 +226,7 @@
             ]
           },
           "mainTemplate": "{{ title }}",
-          "detailsTemplate": "{{ person_name ? person_name + ' - ' : '' }} {{ org_name }}"
+          "detailsTemplate": "{{ person_name ? person_name + ' - ' : '' }} {{ org_name || '' }}"
         },
         {
           "type": "activity",

--- a/components/SAP_C4HANA Grabber.json
+++ b/components/SAP_C4HANA Grabber.json
@@ -4,7 +4,7 @@
       "lead": [
         {
           "type": "lead",
-          "mainTemplate": "{{ ContactFirstName }} {{ ContactLastName }}",
+          "mainTemplate": "{{ ContactFirstName || '' }} {{ ContactLastName || '' }}",
           "detailsTemplate": "{{ Company || ContactEMail }}",
           "duplicateCheckName": "lead",
           "fields": {
@@ -257,7 +257,7 @@
       "contact_account": [
         {
           "type": "contact",
-          "mainTemplate": "{{ FirstName }} {{ LastName }}",
+          "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
           "detailsTemplate": "{{ AccountFormattedName }}",
           "duplicateCheckName": "contact",
           "fields": {
@@ -415,8 +415,8 @@
         },
         {
           "type": "account",
-          "mainTemplate": "{{ BusinessPartnerFormattedName || Name }}",
-          "detailsTemplate": "{{ StreetPostalCode ? StreetPostalCode + ' - ' : '' }}{{ City }}",
+          "mainTemplate": "{{ BusinessPartnerFormattedName || Name || '' }}",
+          "detailsTemplate": "{{ StreetPostalCode ? StreetPostalCode + ' - ' : '' }}{{ City || '' }}",
           "duplicateCheckName": "account",
           "fields": {
             "Name": {

--- a/components/SAP_C4HANA VisitReport.json
+++ b/components/SAP_C4HANA VisitReport.json
@@ -5,7 +5,7 @@
         "lead": [
           {
             "type": "lead",
-            "mainTemplate": "{{ ContactFirstName }} {{ ContactLastName }}",
+            "mainTemplate": "{{ ContactFirstName || '' }} {{ ContactLastName || '' }}",
             "detailsTemplate": "{{ Company || ContactEMail }}",
             "duplicateCheckName": "lead",
             "fields": {
@@ -267,7 +267,7 @@
         "contact_account": [
           {
             "type": "contact",
-            "mainTemplate": "{{ FirstName }} {{ LastName }}",
+            "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
             "detailsTemplate": "{{ AccountFormattedName }}",
             "duplicateCheckName": "contact",
             "fields": {
@@ -426,7 +426,7 @@
           {
             "type": "account",
             "mainTemplate": "{{ BusinessPartnerFormattedName || Name }}",
-            "detailsTemplate": "{{ StreetPostalCode ? StreetPostalCode + ' - ' : '' }}{{ City }}",
+            "detailsTemplate": "{{ StreetPostalCode ? StreetPostalCode + ' - ' : '' }}{{ City || '' }}",
             "duplicateCheckName": "account",
             "fields": {
               "Name": {

--- a/components/SageCRM Grabber.json
+++ b/components/SageCRM Grabber.json
@@ -254,7 +254,7 @@
               "personlastname"
             ]
           },
-          "mainTemplate": "{{ personsalutation }} {{ personfirstname }} {{ personlastname }}",
+          "mainTemplate": "{{ personfirstname || '' }} {{ personlastname || '' }}",
           "detailsTemplate": "{{ company }}"
         }
       ],
@@ -647,7 +647,7 @@
               "lastname"
             ]
           },
-          "mainTemplate": "{{ salutation }} {{ firstname }} {{ lastname }}",
+          "mainTemplate": "{{ firstname || '' }} {{ lastname || '' }}",
           "detailsTemplate": "{{ email.records[0].emailaddress }}"
         },
         {
@@ -983,7 +983,7 @@
             ]
           },
           "mainTemplate": "{{ name }}",
-          "detailsTemplate": "{{ address.records[0].postcode }} {{ address.records[0].city }}"
+          "detailsTemplate": "{{ address.records[0].postcode || '' }} {{ address.records[0].city || '' }}"
         }
       ]
     }

--- a/components/SageCRM Visitreport.json
+++ b/components/SageCRM Visitreport.json
@@ -255,7 +255,7 @@
                 "personlastname"
               ]
             },
-            "mainTemplate": "{{ personsalutation }} {{ personfirstname }} {{ personlastname }}",
+            "mainTemplate": "{{ personfirstname || '' }} {{ personlastname || '' }}",
             "detailsTemplate": "{{ company }}"
           }
         ],
@@ -648,7 +648,7 @@
                 "lastname"
               ]
             },
-            "mainTemplate": "{{ salutation }} {{ firstname }} {{ lastname }}",
+            "mainTemplate": "{{ firstname || '' }} {{ lastname || '' }}",
             "detailsTemplate": "{{ email.records[0].emailaddress }}"
           },
           {
@@ -984,7 +984,7 @@
               ]
             },
             "mainTemplate": "{{ name }}",
-            "detailsTemplate": "{{ address.records[0].postcode }} {{ address.records[0].city }}"
+            "detailsTemplate": "{{ address.records[0].postcode || '' }} {{ address.records[0].city || '' }}"
           }
         ]
       }

--- a/components/Salesforce Grabber.json
+++ b/components/Salesforce Grabber.json
@@ -223,7 +223,7 @@
               "LastName"
             ]
           },
-          "mainTemplate": "{{ FirstName }} {{ LastName }}",
+          "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
           "detailsTemplate": "{{ Company }}"
         },
         {
@@ -483,7 +483,7 @@
               "LastName"
             ]
           },
-          "mainTemplate": "{{ FirstName }} {{ LastName }}",
+          "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
           "detailsTemplate": "{{ Email }}"
         },
         {
@@ -596,7 +596,7 @@
             ]
           },
           "mainTemplate": "{{ Name }}",
-          "detailsTemplate": "{{ BillingPostalCode ? (BillingPostalCode + ' - ') : '' }} {{ BillingCity }}"
+          "detailsTemplate": "{{ BillingPostalCode ? (BillingPostalCode + ' - ') : '' }} {{ BillingCity || '' }}"
         },
         {
           "type": "task",

--- a/components/Salesforce VisitReport.json
+++ b/components/Salesforce VisitReport.json
@@ -224,7 +224,7 @@
                 "LastName"
               ]
             },
-            "mainTemplate": "{{ FirstName }} {{ LastName }}",
+            "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
             "detailsTemplate": "{{ Company }}"
           },
           {
@@ -526,7 +526,7 @@
                 "LastName"
               ]
             },
-            "mainTemplate": "{{ FirstName }} {{ LastName }}",
+            "mainTemplate": "{{ FirstName || '' }} {{ LastName || '' }}",
             "detailsTemplate": "{{ Email }}"
           },
           {
@@ -639,7 +639,7 @@
               ]
             },
             "mainTemplate": "{{ Name }}",
-            "detailsTemplate": "{{ BillingPostalCode ? (BillingPostalCode + ' - ') : '' }} {{ BillingCity }}"
+            "detailsTemplate": "{{ BillingPostalCode ? (BillingPostalCode + ' - ') : '' }} {{ BillingCity || '' }}"
           },
           {
             "type": "campaignMember",

--- a/components/SugarCRM Grabber.json
+++ b/components/SugarCRM Grabber.json
@@ -208,7 +208,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         }
       ],
@@ -381,7 +381,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         }
       ],
@@ -566,7 +566,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         },
         {

--- a/components/SugarCRM VisitReport.json
+++ b/components/SugarCRM VisitReport.json
@@ -209,7 +209,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           }
         ],
@@ -382,7 +382,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           }
         ],
@@ -567,7 +567,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           },
           {

--- a/components/SuiteCRM Grabber.json
+++ b/components/SuiteCRM Grabber.json
@@ -210,7 +210,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         }
       ],
@@ -383,7 +383,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         }
       ],
@@ -568,7 +568,7 @@
               "last_name"
             ]
           },
-          "mainTemplate": "{{ first_name }} {{ last_name }}",
+          "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
           "detailsTemplate": "{{ account_name }}"
         },
         {

--- a/components/SuiteCRM VisitReport.json
+++ b/components/SuiteCRM VisitReport.json
@@ -211,7 +211,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           }
         ],
@@ -384,7 +384,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           }
         ],
@@ -569,7 +569,7 @@
                 "last_name"
               ]
             },
-            "mainTemplate": "{{ first_name }} {{ last_name }}",
+            "mainTemplate": "{{ first_name || '' }} {{ last_name || '' }}",
             "detailsTemplate": "{{ account_name }}"
           },
           {


### PR DESCRIPTION
### Changes
- added empty strings (`|| ''`) to duplicate templates to avoid a [`null`-issue](https://github.com/snapADDY/snapaddy-export-lib/pull/552/)